### PR TITLE
Update bucket ACL to private in repo1

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,7 +1,7 @@
 
         resource "aws_s3_bucket" "bucket" {
           bucket = "example-bucket-name"
-          acl    = "public-read"
+          acl    = "private"
 
           website {
             index_document = "index.html"


### PR DESCRIPTION
This PR updates the bucket ACL from 'public-read' to 'private' in the Terraform configuration.